### PR TITLE
Give a signalled agent the exit code a shell would

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -596,7 +596,7 @@ func execFork(ctx context.Context, src session.Source, model string, stdin io.Re
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	return launchError(cmd.Run())
+	return launchError(name, cmd.Run(), stderr)
 }
 
 type intoRunner func(ctx context.Context, name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error
@@ -608,7 +608,7 @@ func execInto(ctx context.Context, name string, args []string, stdin io.Reader, 
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	return launchError(cmd.Run())
+	return launchError(name, cmd.Run(), stderr)
 }
 
 // ExitError is a launched agent's own exit status on its way out to main,
@@ -624,16 +624,27 @@ type ExitError struct{ Code int }
 
 func (e *ExitError) Error() string { return fmt.Sprintf("exit status %d", e.Code) }
 
-// launchError converts the result of running a launched agent. Only a clean
-// non-zero exit becomes an ExitError; a failure to start it at all — a binary
-// that is not on PATH, an argv the OS refuses — is catchup's own error and
-// keeps its message. A signal leaves no code to pass on, so it stays a plain
-// failure.
-func launchError(err error) error {
+// launchError converts the result of running a launched agent. Only the agent's
+// own ending becomes an ExitError; a failure to start it at all — a binary that
+// is not on PATH, an argv the OS refuses — is catchup's own error and keeps its
+// message.
+//
+// A signal leaves no exit code, so it takes the shell's answer for the same
+// question: 128 plus the number, which is what a wrapper reading $? would have
+// seen had it run the agent itself. That death is worth a line, because the
+// agent had no chance to explain itself and the kernel says nothing to the
+// terminal — but the line names the agent, since catchup is reporting a death
+// it witnessed rather than one of its own.
+func launchError(name string, err error, stderr io.Writer) error {
 	var exit *exec.ExitError
 	if errors.As(err, &exit) {
 		if code := exit.ExitCode(); code > 0 {
 			return &ExitError{Code: code}
+		}
+		if status, ok := exit.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			sig := status.Signal()
+			fmt.Fprintf(stderr, "catchup: %s died: %v\n", name, sig)
+			return &ExitError{Code: 128 + int(sig)}
 		}
 	}
 	return err

--- a/internal/cli/exit_test.go
+++ b/internal/cli/exit_test.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"os/exec"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -20,7 +23,7 @@ func exitCmd(code int) *exec.Cmd {
 
 func TestLaunchErrorCarriesTheAgentsExitCode(t *testing.T) {
 	var exit *ExitError
-	got := launchError(exitCmd(3).Run())
+	got := launchError("codex", exitCmd(3).Run(), io.Discard)
 	if !errors.As(got, &exit) {
 		t.Fatalf("a launched agent's non-zero exit must survive as an ExitError, got %v", got)
 	}
@@ -36,11 +39,33 @@ func TestLaunchErrorLeavesCatchupsOwnFailuresAlone(t *testing.T) {
 	if notFound == nil {
 		t.Fatal("expected the missing binary to fail")
 	}
-	if got := launchError(notFound); !errors.Is(got, notFound) {
+	if got := launchError("codex", notFound, io.Discard); !errors.Is(got, notFound) {
 		t.Errorf("a failure to launch must keep its own message, got %v", got)
 	}
 	// A clean exit is not an error, and must not become one.
-	if got := launchError(exitCmd(0).Run()); got != nil {
+	if got := launchError("codex", exitCmd(0).Run(), io.Discard); got != nil {
 		t.Errorf("want nil for a successful agent, got %v", got)
+	}
+}
+
+func TestLaunchErrorReportsASignalledAgentTheWayAShellWould(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no signals on Windows; a terminated process still carries an exit code")
+	}
+	var errOut bytes.Buffer
+	var exit *ExitError
+	killed := exec.Command("sh", "-c", "kill -TERM $$").Run()
+	got := launchError("codex", killed, &errOut)
+	if !errors.As(got, &exit) {
+		t.Fatalf("a signalled agent must still carry a status out, got %v", got)
+	}
+	// 128+SIGTERM, the number a shell reports for the same death.
+	if exit.Code != 143 {
+		t.Errorf("want 143 for SIGTERM, got %d", exit.Code)
+	}
+	// The agent said nothing before dying, so the line has to name it — and
+	// must not read as a catchup failure.
+	if line := errOut.String(); !strings.Contains(line, "codex died: terminated") {
+		t.Errorf("want the death attributed to the agent, got %q", line)
 	}
 }


### PR DESCRIPTION
#13 passed the launched agent's exit code through, but a signal carries no exit code, so one ending was left behind:

```
$ catchup fork claude          # the agent is OOM-killed
catchup: signal: killed
$ echo $?
1
```

That is catchup's name over a death that was not catchup's — the attribution #13 removed everywhere else — and a wrapper learns nothing from the 1. It is also the shape #12's triage rule misreads: an agent told that "a non-zero exit from `fork` is the launched agent's own status" sees a `catchup:`-prefixed error here and files a bug.

A signalled agent now exits 128 plus the signal number, which is the answer a shell gives for the same death, so `$?` is 137 for a `kill -9` and 139 for a segfault. The death still gets one line, because the agent had no chance to explain itself and the kernel says nothing to the terminal — but the line names the agent:

```
catchup: claude died: killed
catchup: claude died: terminated
catchup: claude died: segmentation fault
```

`syscall.WaitStatus.Signaled()` and `.Signal()` are defined on Windows and macOS as well as Linux, so this needs no build tags; on Windows a terminated process still carries an exit code and takes the existing path. Verified end to end with SIGKILL, SIGTERM and SIGSEGV (137/143/139); the new test skips on Windows.